### PR TITLE
Produce test result output in JUnit XML format to generate Allure report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,10 +76,6 @@ pkgs/.stack
 **/.spago/
 **/.spago2nix/
 **/.psa-stash
-plutus-pab-executables/demo/pab-nami/client/generated
-
-# Backend config files
-plutus-pab/plutus-pab.yaml
 
 # Misc
 .history/
@@ -112,3 +108,6 @@ plutus-pab/test-node/alonzo-purple/db
 # profiling output files
 *.timelog
 *.stacks
+
+# Test results
+*/test-report-xml

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Antaeus is currently under development, with a growing suite of tests covering:
 
 ---
 
-### Allure Report !!! TODO: REFINE SECTION !!!
+### Test Report TMP
 
-JUnit XML report is first produced in e2e-tests/test-report-xml/test-results.xml
-Run `allure serve <test-report-xml>` to generate and host the Allure report
+After every test run a JUnit XML report is produced in e2e-tests/test-report-xml/test-results.xml. An existing report will be overwritten.
+Run `allure serve <test-report-xml>` to generate and host the Allure report.
 
 ### Planned Features
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@ Antaeus is currently under development, with a growing suite of tests covering:
 
 ---
 
+### Allure Report !!! TODO: REFINE SECTION !!!
+
+JUnit XML report is first produced in e2e-tests/test-report-xml/test-results.xml
+Run `allure serve <test-report-xml>` to generate and host the Allure report
+
 ### Planned Features
 
 We're working on adding the following features to Antaeus:
 
 - CI execution with private testnet on commit (nix configuration coming soon).
-- Test reporting with [Allure](https://github.com/allure-framework).
 - Nightly CI test execution would be useful in public environments.
 
 ---

--- a/e2e-tests/e2e-tests.cabal
+++ b/e2e-tests/e2e-tests.cabal
@@ -144,3 +144,4 @@ test-suite antaeus-test
     , tasty
     , tasty-hedgehog
     , temporary
+    , xml

--- a/e2e-tests/e2e-tests.cabal
+++ b/e2e-tests/e2e-tests.cabal
@@ -98,6 +98,7 @@ test-suite antaeus-test
     Helpers.Query
     Helpers.ScriptUtils
     Helpers.Test
+    Helpers.TestData
     Helpers.Testnet
     Helpers.TestResults
     Helpers.Tx

--- a/e2e-tests/e2e-tests.cabal
+++ b/e2e-tests/e2e-tests.cabal
@@ -99,6 +99,7 @@ test-suite antaeus-test
     Helpers.ScriptUtils
     Helpers.Test
     Helpers.Testnet
+    Helpers.TestResults
     Helpers.Tx
     Helpers.TypeConverters
     Helpers.Utils
@@ -134,6 +135,7 @@ test-suite antaeus-test
     , bytestring
     , containers
     , directory
+    , exceptions
     , filepath
     , hedgehog
     , hedgehog-extras

--- a/e2e-tests/test/Helpers/Query.hs
+++ b/e2e-tests/test/Helpers/Query.hs
@@ -191,3 +191,4 @@ txOutHasValue :: (MonadIO m)
 txOutHasValue (C.TxOut _ txOutValue _ _) tokenValue = do
   let value = C.txOutValueToValue txOutValue
   return $ isInfixOf (C.valueToList tokenValue) (C.valueToList value)
+

--- a/e2e-tests/test/Helpers/Test.hs
+++ b/e2e-tests/test/Helpers/Test.hs
@@ -1,48 +1,35 @@
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 module Helpers.Test (
-    TestParams(..),
     runTest,
-    runTestWithPosixTime,
-
     assert,
     failure,
     success
 ) where
 
-import Cardano.Api qualified as C
-import Cardano.Api.Shelley qualified as C
 import CardanoTestnet qualified as TN
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.IORef (IORef)
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Maybe (isNothing)
 import Data.Time.Clock.POSIX qualified as Time
 import GHC.IORef (atomicModifyIORef')
 import GHC.Stack (HasCallStack, callStack, prettyCallStack, withFrozenCallStack)
 import Hedgehog (MonadTest)
 import Hedgehog qualified as H
-import Helpers.TestResults (TestInfo (..), TestResult (..))
+import Helpers.TestData (TestInfo (..), TestParams (..))
+import Helpers.TestResults (TestResult (..))
 import Helpers.Testnet qualified as TN
 import Text.Printf (printf)
 
-data TestParams = TestParams {
-    localNodeConnectInfo :: C.LocalNodeConnectInfo C.CardanoMode,
-    pparams              :: C.ProtocolParameters,
-    networkId            :: C.NetworkId,
-    tempAbsPath          :: FilePath
-}
-
-runTestGeneric :: MonadIO m =>
+runTest :: (MonadIO m, MonadTest m) =>
   TestInfo ->
-  (Either TN.LocalNodeOptions TN.TestnetOptions -> TestParams -> Time.POSIXTime -> m (Maybe String)) ->
   IORef [TestResult] ->
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  Maybe Time.POSIXTime ->
   m ()
-runTestGeneric testInfo test resultsRef networkOptions testParams preTestnetTime = do
+runTest testInfo resultsRef networkOptions testParams = do
   liftIO $ putStrLn $ "\nRunning: " ++ testName testInfo
   t <- liftIO Time.getPOSIXTime
-  mError <- test networkOptions testParams (fromMaybe t preTestnetTime)
+  mError <- test testInfo networkOptions testParams
   t2 <- liftIO Time.getPOSIXTime
   let diff = realToFrac $ t2 - t :: Double
   case mError of
@@ -50,32 +37,11 @@ runTestGeneric testInfo test resultsRef networkOptions testParams preTestnetTime
     Just e  -> liftIO $ putStrLn $ "Result: Fail\nDuration: " ++ printf "%.2f" diff ++ "s" ++ "\nFailure message: " ++ e
   let result = TestResult
         { resultTestInfo = testInfo
-        , resultSuccessful = isNothing mError -- TODO: support test failure
+        , resultSuccessful = isNothing mError
         , resultFailure = mError
         , resultTime = diff
         }
   liftIO $ atomicModifyIORef' resultsRef (\results -> (result : results, ()))
-
-runTest :: MonadIO m =>
-  TestInfo ->
-  (Either TN.LocalNodeOptions TN.TestnetOptions -> TestParams -> m (Maybe String)) ->
-  IORef [TestResult] ->
-  Either TN.LocalNodeOptions TN.TestnetOptions ->
-  TestParams ->
-  m ()
-runTest testInfo test resultsRef networkOptions testParams =
-  runTestGeneric testInfo (\opts params _ -> test opts params) resultsRef networkOptions testParams Nothing
-
-runTestWithPosixTime :: MonadIO m =>
-  TestInfo ->
-  (Either TN.LocalNodeOptions TN.TestnetOptions -> TestParams -> Time.POSIXTime -> m (Maybe String)) ->
-  IORef [TestResult] ->
-  Either TN.LocalNodeOptions TN.TestnetOptions ->
-  TestParams ->
-  Time.POSIXTime ->
-  m ()
-runTestWithPosixTime testInfo test resultsRef networkOptions testParams preTestnetTime =
-    runTestGeneric testInfo test resultsRef networkOptions testParams (Just preTestnetTime)
 
 success :: MonadTest m => m (Maybe String)
 success = return Nothing
@@ -83,8 +49,6 @@ success = return Nothing
 failure :: (MonadTest m) => String -> m (Maybe String)
 failure s = do
     let message = s ++ "\n\n" ++ prettyCallStack callStack
-    --let src = prettyCallStack callStack --getCaller callStack
-    --withFrozenCallStack $ annotateShow s
     return $ Just message
 
 assert :: (MonadTest m, HasCallStack) => String -> Bool -> m (Maybe String)

--- a/e2e-tests/test/Helpers/TestData.hs
+++ b/e2e-tests/test/Helpers/TestData.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE RankNTypes #-}
+module Helpers.TestData where
+import Cardano.Api qualified as C
+import Cardano.Api.Shelley qualified as C
+import CardanoTestnet qualified as TN
+import Control.Monad.IO.Class (MonadIO)
+import Data.Time.Clock.POSIX (POSIXTime)
+import Hedgehog (MonadTest)
+import Helpers.Testnet qualified as TN
+
+type TestFunction = forall m. (MonadIO m, MonadTest m) =>
+                Either TN.LocalNodeOptions TN.TestnetOptions ->
+                TestParams ->
+                m (Maybe String)
+
+data TestInfo = TestInfo {
+    testName        :: String,
+    testDescription :: String,
+    test            :: TestFunction
+}
+
+instance Show TestInfo where
+  show (TestInfo name description _) =
+    "TestInfo { testName = " ++ show name ++
+    ", testDescription = " ++ show description ++ " }"
+
+data TestParams = TestParams {
+    localNodeConnectInfo :: C.LocalNodeConnectInfo C.CardanoMode,
+    pparams              :: C.ProtocolParameters,
+    networkId            :: C.NetworkId,
+    tempAbsPath          :: FilePath,
+    mTime                :: Maybe POSIXTime
+}

--- a/e2e-tests/test/Helpers/TestResults.hs
+++ b/e2e-tests/test/Helpers/TestResults.hs
@@ -8,6 +8,7 @@ module Helpers.TestResults (
     testSuitesToJUnit
 ) where
 
+import Data.Maybe (fromJust)
 import Text.XML.Light (Attr (Attr), CData (CData), CDataKind (CDataText), Content (Elem, Text), Element (..),
                        QName (QName))
 
@@ -24,6 +25,7 @@ data TestSuiteResults = TestSuiteResults {
 data TestResult = TestResult {
     resultTestInfo   :: TestInfo,
     resultSuccessful :: Bool,
+    resultFailure    :: Maybe String, -- TODO: use this in failureElement in xml output
     resultTime       :: Double
 } deriving Show
 
@@ -77,8 +79,8 @@ testCaseToJUnit suiteName result = defElement
       , elContent = []
       }
 
-    failureElement = defElement -- TODO: make framework handle test failures, not exit Property.
+    failureElement = defElement -- TODO: make framework handle test failures
       { elName = QName "failure" Nothing Nothing
-      , elAttribs = [Attr (QName "type" Nothing Nothing) "AssertionError"] -- example type
-      , elContent = [Text $ CData CDataText (testName $ resultTestInfo result) Nothing]
+      , elAttribs = [Attr (QName "message" Nothing Nothing) "test failure"] -- example type
+      , elContent = [Text $ CData CDataText (fromJust (resultFailure result)) Nothing]
       }

--- a/e2e-tests/test/Helpers/TestResults.hs
+++ b/e2e-tests/test/Helpers/TestResults.hs
@@ -1,0 +1,84 @@
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+{-# OPTIONS_GHC -Wno-missing-fields #-}
+{-# LANGUAGE RecordWildCards #-}
+module Helpers.TestResults (
+    TestInfo(..),
+    TestSuiteResults(..),
+    TestResult(..),
+    testSuitesToJUnit
+) where
+
+import Text.XML.Light (Attr (Attr), CData (CData), CDataKind (CDataText), Content (Elem, Text), Element (..),
+                       QName (QName))
+
+data TestInfo = TestInfo {
+    testName        :: String,
+    testDescription :: String
+} deriving Show
+
+data TestSuiteResults = TestSuiteResults {
+    suiteName    :: String,
+    suiteResults ::  [TestResult]
+} deriving Show
+
+data TestResult = TestResult {
+    resultTestInfo   :: TestInfo,
+    resultSuccessful :: Bool,
+    resultTime       :: Double
+} deriving Show
+
+defElement :: Element
+defElement = Element {elLine = Nothing}
+
+-- top level - all Property test suites
+testSuitesToJUnit :: [TestSuiteResults] -> Element
+testSuitesToJUnit testSuites = defElement
+  { elName = QName "testsuites" Nothing Nothing
+  , elAttribs = [ Attr (QName "name" Nothing Nothing) "Antaeus E2E Tests"
+                , Attr (QName "tests" Nothing Nothing)
+                    (show $ map (\testSuite -> length $ suiteResults testSuite) testSuites)
+                ]
+  , elContent = map (Elem . testSuiteToJUnit) testSuites
+  }
+
+-- each Property (e.g. pv6Tests)
+testSuiteToJUnit :: TestSuiteResults -> Element
+testSuiteToJUnit TestSuiteResults{..} = defElement
+  { elName = QName "testsuite" Nothing Nothing
+  , elAttribs = [ Attr (QName "name" Nothing Nothing) suiteName
+                , Attr (QName "tests" Nothing Nothing) (show $ length suiteResults)
+                ]
+  , elContent = map (Elem . testCaseToJUnit suiteName) suiteResults
+  }
+
+-- each runTest within Property
+testCaseToJUnit :: String -> TestResult -> Element
+testCaseToJUnit suiteName result = defElement
+  { elName = QName "testcase" Nothing Nothing
+  , elAttribs = [ Attr (QName "name" Nothing Nothing) (testName $ resultTestInfo result)
+                , Attr (QName "classname" Nothing Nothing) suiteName
+                , Attr (QName "time" Nothing Nothing) (show $ resultTime result)
+                ]
+  , elContent = if resultSuccessful result
+                  then [ Elem propertiesElement ]
+                  else [ Elem failureElement
+                       , Elem propertiesElement ]
+  }
+  where
+    propertiesElement= defElement
+      { elName = QName "properties" Nothing Nothing
+      , elAttribs = []
+      , elContent = [Elem descriptionProperty]
+      }
+    descriptionProperty = defElement
+      { elName = QName "property" Nothing Nothing
+      , elAttribs = [ Attr (QName "name" Nothing Nothing) "description"
+                    , Attr (QName "value" Nothing Nothing) (testDescription $ resultTestInfo result) ]
+      , elContent = []
+      }
+
+    failureElement = defElement -- TODO: make framework handle test failures, not exit Property.
+      { elName = QName "failure" Nothing Nothing
+      , elAttribs = [Attr (QName "type" Nothing Nothing) "AssertionError"] -- example type
+      , elContent = [Text $ CData CDataText (testName $ resultTestInfo result) Nothing]
+      }

--- a/e2e-tests/test/Helpers/Testnet.hs
+++ b/e2e-tests/test/Helpers/Testnet.hs
@@ -38,7 +38,7 @@ data LocalNodeOptions = LocalNodeOptions
   , protocolVersion :: Int
   , localEnvDir     :: FilePath -- path to directory containing 'utxo-keys' and 'ipc' directories
   , testnetMagic    :: Int
-  }
+  } deriving Show
 
 localNodeOptionsPreview :: Either LocalNodeOptions TN.TestnetOptions
 localNodeOptionsPreview = Left $ LocalNodeOptions

--- a/e2e-tests/test/Helpers/Utils.hs
+++ b/e2e-tests/test/Helpers/Utils.hs
@@ -64,9 +64,9 @@ maybeReadAs as path = do
   where
     maybeEither m = m >>= return . either (const Nothing) Just
 
--- | Concatentate Just Strings. Useful for aggregating test failures.
-concatMaybesList :: MonadTest m => [Maybe String] -> m (Maybe String)
-concatMaybesList mList =
+-- | Concatenate Just Strings. Useful for aggregating test failures.
+concatMaybes :: MonadTest m => [Maybe String] -> m (Maybe String)
+concatMaybes mList =
   let justStrings = map (maybe "" id) mList
       withLineBreaks = mconcat . intersperse "\n\n" $ justStrings
   in if all null justStrings then pure Nothing else pure $ Just withLineBreaks

--- a/e2e-tests/test/Helpers/Utils.hs
+++ b/e2e-tests/test/Helpers/Utils.hs
@@ -4,13 +4,14 @@ import Cardano.Api qualified as C
 import Control.Monad (when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Functor (void)
+import Data.List (intersperse)
 import Data.Time.Clock.POSIX qualified as Time
 import GHC.Stack qualified as GHC
 import Hedgehog (MonadTest)
 import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
 import Hedgehog.Extras qualified as HE
 import Hedgehog.Extras.Stock.CallStack qualified as H
-import Hedgehog.Extras.Test.Base qualified as H
 import System.Directory qualified as IO
 import System.Environment qualified as IO
 import System.IO qualified as IO
@@ -62,6 +63,13 @@ maybeReadAs as path = do
   maybeEither . liftIO $ C.readFileTextEnvelope as path'
   where
     maybeEither m = m >>= return . either (const Nothing) Just
+
+-- | Concatentate Just Strings. Useful for aggregating test failures.
+concatMaybesList :: MonadTest m => [Maybe String] -> m (Maybe String)
+concatMaybesList mList =
+  let justStrings = map (maybe "" id) mList
+      withLineBreaks = mconcat . intersperse "\n\n" $ justStrings
+  in if all null justStrings then pure Nothing else pure $ Just withLineBreaks
 
 -- | Convert a 'POSIXTime' to the number of milliseconds since the Unix epoch.
 posixToMilliseconds :: Time.POSIXTime -> Integer

--- a/e2e-tests/test/Spec.hs
+++ b/e2e-tests/test/Spec.hs
@@ -1,138 +1,180 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
 
-{- | Tests covering the integration of local modules and external packages. To name a few:
-    Trace Emulator, plutus-tx-constraints, Contract.Test library,
-    plutus-tx and plutus-ledger-api.
-    Scenarios aim to use a variety of functions and assert relevant properties.
-    Can also be considered living documentation for Contract and Tx Constraint use.
--}
 module Main(main) where
 
+import CardanoTestnet qualified as TN
+import Control.Exception (SomeException)
+import Control.Exception.Base (try)
 import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.IORef (IORef, readIORef)
 import Data.Time.Clock.POSIX qualified as Time
+import GHC.IORef (newIORef)
 import Hedgehog qualified as H
 import Hedgehog.Extras qualified as HE
 import Helpers.Test (TestParams (TestParams), runTest, runTestWithPosixTime)
+import Helpers.TestResults (TestResult, TestSuiteResults (..), testSuitesToJUnit)
 import Helpers.Testnet qualified as TN
 import Helpers.Utils qualified as U
-import Spec.AlonzoFeatures qualified as AlonzoFeatures
-import Spec.BabbageFeatures qualified as BabbageFeatures
+import Spec.AlonzoFeatures qualified as Alonzo
+import Spec.BabbageFeatures qualified as Babbage
 import Spec.Builtins.SECP256k1 qualified as Builtins
+import System.Directory (createDirectoryIfMissing)
 import Test.Base qualified as H
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
+import Text.XML.Light (showTopElement)
+
 
 main :: IO ()
-main = defaultMain tests
+main = do
+  runTestsWithResults
 
-pv6Tests :: H.Property
-pv6Tests = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+
+tests :: IORef [TestResult] -> IORef [TestResult] -> IORef [TestResult] ->  TestTree
+tests pv6ResultsRef pv7ResultsRef pv8ResultsRef = testGroup "Plutus E2E Tests" [
+  testProperty "Alonzo PV6 Tests" (pv6Tests pv6ResultsRef)
+  , testProperty "Babbage PV7 Tests" (pv7Tests pv7ResultsRef)
+  , testProperty "Babbage PV8 Tests" (pv8Tests pv8ResultsRef)
+--   , testProperty "debug" (debugTests pv8ResultsRef)
+--   , testProperty "Babbage PV8 Tests (on Preview testnet)" (localNodeTests pv8ResultsRef TN.localNodeOptionsPreview)
+  ]
+
+pv6Tests :: IORef [TestResult] -> H.Property
+pv6Tests resultsRef = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
     let options = TN.testnetOptionsAlonzo6
     preTestnetTime <- liftIO Time.getPOSIXTime
     (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
     let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+        run name test = runTest name test resultsRef options testParams
+        runWithPosixTime name test = runTestWithPosixTime name test resultsRef options testParams preTestnetTime
 
-    -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
-    runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
-    runTest "datumHashSpendTest" AlonzoFeatures.datumHashSpendTest options testParams
-    runTest "mintBurnTest" AlonzoFeatures.mintBurnTest options testParams
-    runTest "collateralContainsTokenErrorTest" AlonzoFeatures.collateralContainsTokenErrorTest options testParams
-    runTest "noCollateralInputsErrorTest" AlonzoFeatures.noCollateralInputsErrorTest options testParams
-    runTest "missingCollateralInputErrorTest" AlonzoFeatures.missingCollateralInputErrorTest options testParams
-    runTest "tooManyCollateralInputsErrorTest" AlonzoFeatures.tooManyCollateralInputsErrorTest options testParams
-    runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
+    sequence_
+      [ runWithPosixTime Alonzo.checkTxInfoV1TestInfo Alonzo.checkTxInfoV1Test
+      , run Alonzo.datumHashSpendTestInfo Alonzo.datumHashSpendTest
+      , run Alonzo.mintBurnTestInfo Alonzo.mintBurnTest
+      , run Alonzo.collateralContainsTokenErrorTestInfo Alonzo.collateralContainsTokenErrorTest
+      , run Alonzo.noCollateralInputsErrorTestInfo Alonzo.noCollateralInputsErrorTest
+      , run Alonzo.missingCollateralInputErrorTestInfo Alonzo.missingCollateralInputErrorTest
+      , run Alonzo.tooManyCollateralInputsErrorTestInfo Alonzo.tooManyCollateralInputsErrorTest
+      , run Builtins.verifySchnorrAndEcdsaTestInfo Builtins.verifySchnorrAndEcdsaTest
+      ]
 
     U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
 
-pv7Tests :: H.Property
-pv7Tests = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+
+pv7Tests :: IORef [TestResult] ->  H.Property
+pv7Tests resultsRef = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
     let options = TN.testnetOptionsBabbage7
     preTestnetTime <- liftIO Time.getPOSIXTime
     (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
     let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+        run name test = runTest name test resultsRef options testParams
+        runWithPosixTime name test = runTestWithPosixTime name test resultsRef options testParams preTestnetTime
 
     -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
-    runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
-    runTestWithPosixTime "checkTxInfoV2Test" BabbageFeatures.checkTxInfoV2Test options testParams preTestnetTime
-    runTest "datumHashSpendTest" AlonzoFeatures.datumHashSpendTest options testParams
-    runTest "mintBurnTest" AlonzoFeatures.mintBurnTest options testParams
-    runTest "collateralContainsTokenErrorTest" AlonzoFeatures.collateralContainsTokenErrorTest options testParams
-    runTest "noCollateralInputsErrorTest" AlonzoFeatures.noCollateralInputsErrorTest options testParams
-    runTest "missingCollateralInputErrorTest" AlonzoFeatures.missingCollateralInputErrorTest options testParams
-    runTest "tooManyCollateralInputsErrorTest" AlonzoFeatures.tooManyCollateralInputsErrorTest options testParams
-    runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
-    runTest "referenceScriptMintTest" BabbageFeatures.referenceScriptMintTest options testParams
-    runTest "referenceScriptInlineDatumSpendTest" BabbageFeatures.referenceScriptInlineDatumSpendTest options testParams
-    runTest "referenceScriptDatumHashSpendTest" BabbageFeatures.referenceScriptDatumHashSpendTest options testParams
-    runTest "inlineDatumSpendTest" BabbageFeatures.inlineDatumSpendTest options testParams
-    runTest "referenceInputWithV1ScriptErrorTest" BabbageFeatures.referenceInputWithV1ScriptErrorTest options testParams
-    runTest "referenceScriptOutputWithV1ScriptErrorTest" BabbageFeatures.referenceScriptOutputWithV1ScriptErrorTest options testParams
-    runTest "inlineDatumOutputWithV1ScriptErrorTest" BabbageFeatures.inlineDatumOutputWithV1ScriptErrorTest options testParams
+    sequence_
+      [  runWithPosixTime Alonzo.checkTxInfoV1TestInfo Alonzo.checkTxInfoV1Test
+       , runWithPosixTime Babbage.checkTxInfoV2TestInfo Babbage.checkTxInfoV2Test
+       , run Alonzo.datumHashSpendTestInfo Alonzo.datumHashSpendTest
+       , run Alonzo.mintBurnTestInfo Alonzo.mintBurnTest
+       , run Alonzo.collateralContainsTokenErrorTestInfo Alonzo.collateralContainsTokenErrorTest
+       , run Alonzo.noCollateralInputsErrorTestInfo Alonzo.noCollateralInputsErrorTest
+       , run Alonzo.missingCollateralInputErrorTestInfo Alonzo.missingCollateralInputErrorTest
+       , run Alonzo.tooManyCollateralInputsErrorTestInfo Alonzo.tooManyCollateralInputsErrorTest
+       , run Builtins.verifySchnorrAndEcdsaTestInfo Builtins.verifySchnorrAndEcdsaTest
+       , run Babbage.referenceScriptMintTestInfo Babbage.referenceScriptMintTest
+       , run Babbage.referenceScriptInlineDatumSpendTestInfo Babbage.referenceScriptInlineDatumSpendTest
+       , run Babbage.referenceScriptDatumHashSpendTestInfo Babbage.referenceScriptDatumHashSpendTest
+       , run Babbage.inlineDatumSpendTestInfo Babbage.inlineDatumSpendTest
+       , run Babbage.referenceInputWithV1ScriptErrorTestInfo Babbage.referenceInputWithV1ScriptErrorTest
+       , run Babbage.referenceScriptOutputWithV1ScriptErrorTestInfo Babbage.referenceScriptOutputWithV1ScriptErrorTest
+       , run Babbage.inlineDatumOutputWithV1ScriptErrorTestInfo Babbage.inlineDatumOutputWithV1ScriptErrorTest
+      ]
 
     U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
 
-pv8Tests :: H.Property
-pv8Tests = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+pv8Tests :: IORef [TestResult] -> H.Property
+pv8Tests resultsRef = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
     let options = TN.testnetOptionsBabbage8
     preTestnetTime <- liftIO Time.getPOSIXTime
     (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
     let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+        run name test = runTest name test resultsRef options testParams
+        runWithPosixTime name test = runTestWithPosixTime name test resultsRef options testParams preTestnetTime
 
     -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
-    runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
-    runTestWithPosixTime "checkTxInfoV2Test" BabbageFeatures.checkTxInfoV2Test options testParams preTestnetTime
-    runTest "datumHashSpendTest" AlonzoFeatures.datumHashSpendTest options testParams
-    runTest "mintBurnTest" AlonzoFeatures.mintBurnTest options testParams
-    runTest "collateralContainsTokenErrorTest" AlonzoFeatures.collateralContainsTokenErrorTest options testParams
-    runTest "noCollateralInputsErrorTest" AlonzoFeatures.noCollateralInputsErrorTest options testParams
-    runTest "missingCollateralInputErrorTest" AlonzoFeatures.missingCollateralInputErrorTest options testParams
-    runTest "tooManyCollateralInputsErrorTest" AlonzoFeatures.tooManyCollateralInputsErrorTest options testParams
-    runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
-    runTest "referenceScriptMintTest" BabbageFeatures.referenceScriptMintTest options testParams
-    runTest "referenceScriptInlineDatumSpendTest" BabbageFeatures.referenceScriptInlineDatumSpendTest options testParams
-    runTest "referenceScriptDatumHashSpendTest" BabbageFeatures.referenceScriptDatumHashSpendTest options testParams
-    runTest "inlineDatumSpendTest" BabbageFeatures.inlineDatumSpendTest options testParams
-    runTest "referenceInputWithV1ScriptErrorTest" BabbageFeatures.referenceInputWithV1ScriptErrorTest options testParams
-    runTest "referenceScriptOutputWithV1ScriptErrorTest" BabbageFeatures.referenceScriptOutputWithV1ScriptErrorTest options testParams
-    runTest "inlineDatumOutputWithV1ScriptErrorTest" BabbageFeatures.inlineDatumOutputWithV1ScriptErrorTest options testParams
-    runTest "returnCollateralWithTokensValidScriptTest" BabbageFeatures.returnCollateralWithTokensValidScriptTest options testParams
-    runTest "submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest" BabbageFeatures.submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest options testParams
+    sequence_
+      [  runWithPosixTime Alonzo.checkTxInfoV1TestInfo Alonzo.checkTxInfoV1Test
+       , runWithPosixTime Babbage.checkTxInfoV2TestInfo Babbage.checkTxInfoV2Test
+       , run Alonzo.datumHashSpendTestInfo Alonzo.datumHashSpendTest
+       , run Alonzo.mintBurnTestInfo Alonzo.mintBurnTest
+       , run Alonzo.collateralContainsTokenErrorTestInfo Alonzo.collateralContainsTokenErrorTest
+       , run Alonzo.noCollateralInputsErrorTestInfo Alonzo.noCollateralInputsErrorTest
+       , run Alonzo.missingCollateralInputErrorTestInfo Alonzo.missingCollateralInputErrorTest
+       , run Alonzo.tooManyCollateralInputsErrorTestInfo Alonzo.tooManyCollateralInputsErrorTest
+       , run Builtins.verifySchnorrAndEcdsaTestInfo Builtins.verifySchnorrAndEcdsaTest
+       , run Babbage.referenceScriptMintTestInfo Babbage.referenceScriptMintTest
+       , run Babbage.referenceScriptInlineDatumSpendTestInfo Babbage.referenceScriptInlineDatumSpendTest
+       , run Babbage.referenceScriptDatumHashSpendTestInfo Babbage.referenceScriptDatumHashSpendTest
+       , run Babbage.inlineDatumSpendTestInfo Babbage.inlineDatumSpendTest
+       , run Babbage.referenceInputWithV1ScriptErrorTestInfo Babbage.referenceInputWithV1ScriptErrorTest
+       , run Babbage.referenceScriptOutputWithV1ScriptErrorTestInfo Babbage.referenceScriptOutputWithV1ScriptErrorTest
+       , run Babbage.inlineDatumOutputWithV1ScriptErrorTestInfo Babbage.inlineDatumOutputWithV1ScriptErrorTest
+       , run Babbage.returnCollateralWithTokensValidScriptTestInfo Babbage.returnCollateralWithTokensValidScriptTest
+       , run Babbage.submitWithInvalidScriptThenCollateralIsTakenAndReturnedTestInfo Babbage.submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest
+      ]
 
     U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
 
-debug :: H.Property
-debug = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+debugTests :: IORef [TestResult] -> H.Property
+debugTests resultsRef = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
     let options = TN.testnetOptionsBabbage8
     (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
     let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
 
     -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
-    runTest "noCollateralInputsErrorTest" AlonzoFeatures.noCollateralInputsErrorTest options testParams
+    runTest Alonzo.noCollateralInputsErrorTestInfo Alonzo.noCollateralInputsErrorTest resultsRef options testParams
 
     U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
 
--- localNodeTests :: Either TN.LocalNodeOptions TN.TestnetOptions -> H.Property
--- localNodeTests  options = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
---     --preTestnetTime <- liftIO Time.getPOSIXTime
---     (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
---     let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+localNodeTests :: IORef [TestResult] -> Either TN.LocalNodeOptions TN.TestnetOptions -> H.Property
+localNodeTests resultsRef options = H.integration . HE.runFinallies . U.workspace "." $ \tempAbsPath -> do
+    --preTestnetTime <- liftIO Time.getPOSIXTime
+    (localNodeConnectInfo, pparams, networkId, mPoolNodes) <- TN.setupTestEnvironment options tempAbsPath
+    let testParams = TestParams localNodeConnectInfo pparams networkId tempAbsPath
+        run name test = runTest name test resultsRef options testParams
 
---     -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
---     -- TODO: pass in or query for slot range to use in checkTxInfo tests
---     --runTestWithPosixTime "checkTxInfoV1Test" AlonzoFeatures.checkTxInfoV1Test options testParams preTestnetTime
---     --runTestWithPosixTime "checkTxInfoV2Test" BabbageFeatures.checkTxInfoV2Test options testParams preTestnetTime
---     runTest "verifySchnorrAndEcdsaTest" Builtins.verifySchnorrAndEcdsaTest options testParams
---     runTest "referenceScriptMintTest" BabbageFeatures.referenceScriptMintTest options testParams
---     runTest "referenceScriptInlineDatumSpendTest" BabbageFeatures.referenceScriptInlineDatumSpendTest options testParams
---     runTest "referenceScriptDatumHashSpendTest" BabbageFeatures.referenceScriptDatumHashSpendTest options testParams
+    -- checkTxInfo tests must be first to run after new testnet is initialised due to expected slot to posix time
+    -- TODO: pass in or query for slot range to use in checkTxInfo tests
+    --runTestWithPosixTime "checkTxInfoV1Test" Alonzo.checkTxInfoV1Test options testParams preTestnetTime
+    --runTestWithPosixTime "checkTxInfoV2Test" Babbage.checkTxInfoV2Test options testParams preTestnetTime
+    run Builtins.verifySchnorrAndEcdsaTestInfo Builtins.verifySchnorrAndEcdsaTest
+    run Babbage.referenceScriptMintTestInfo Babbage.referenceScriptMintTest
+    run Babbage.referenceScriptInlineDatumSpendTestInfo Babbage.referenceScriptInlineDatumSpendTest
+    run Babbage.referenceScriptDatumHashSpendTestInfo Babbage.referenceScriptDatumHashSpendTest
 
---     U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
+    U.anyLeftFail_ $ TN.cleanupTestnet mPoolNodes
 
-tests :: TestTree
-tests = testGroup "Plutus E2E Tests" [
-  testProperty "Alonzo PV6 Tests" pv6Tests,
-  testProperty "Babbage PV7 Tests" pv7Tests,
-  testProperty "Babbage PV8 Tests" pv8Tests
-  --testProperty "debug" debug
-  --testProperty "Babbage PV8 Tests (on Preview testnet)" $ localNodeTests TN.localNodeOptionsPreview
-  ]
+runTestsWithResults :: IO ()
+runTestsWithResults = do
+  createDirectoryIfMissing False "test-report-xml"
+
+  [pv6ResultsRef, pv7ResultsRef, pv8ResultsRef] <- traverse newIORef [[], [], []]
+
+  -- Catch the exception returned by defaultMain to proceed with report generation
+  _ <- try (defaultMain $ tests pv6ResultsRef pv7ResultsRef pv8ResultsRef) :: IO (Either SomeException ())
+
+  [pv6Results, pv7Results, pv8Results] <- traverse readIORef [pv6ResultsRef, pv7ResultsRef, pv8ResultsRef]
+  -- putStrLn $ "Debug final results: " ++ show results -- REMOVE
+
+  let
+    pv6TestSuiteResult = TestSuiteResults "Alonzo PV6 Tests"  pv6Results
+    pv7TestSuiteResult = TestSuiteResults "Babbage PV7 Tests" pv7Results
+    pv8TestSuiteResult = TestSuiteResults "Babbage PV8 Tests" pv8Results
+
+  -- Use 'results' to generate custom JUnit XML report
+  let xml = testSuitesToJUnit [pv6TestSuiteResult, pv7TestSuiteResult, pv8TestSuiteResult]
+  -- putStrLn $ "Debug XML: " ++ showTopElement xml -- REMOVE
+  writeFile "test-report-xml/test-results.xml" $ showTopElement xml

--- a/e2e-tests/test/Spec/AlonzoFeatures.hs
+++ b/e2e-tests/test/Spec/AlonzoFeatures.hs
@@ -5,16 +5,11 @@
 
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-} -- Not using all CardanoEra
 {-# LANGUAGE RecordWildCards     #-}
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-module Spec.AlonzoFeatures (
-    checkTxInfoV1Test,
-    datumHashSpendTest,
-    mintBurnTest,
-    collateralContainsTokenErrorTest,
-    missingCollateralInputErrorTest,
-    noCollateralInputsErrorTest,
-    tooManyCollateralInputsErrorTest
-    ) where
+module Spec.AlonzoFeatures where
 
 import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C
@@ -28,6 +23,7 @@ import Hedgehog qualified as H
 import Helpers.Common (makeAddress)
 import Helpers.Query qualified as Q
 import Helpers.Test (TestParams (TestParams, localNodeConnectInfo, networkId, pparams, tempAbsPath))
+import Helpers.TestResults (TestInfo (..))
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
 import Helpers.Utils qualified as U
@@ -40,6 +36,11 @@ import PlutusScripts.Helpers qualified as PS
 import PlutusScripts.V1TxInfo (checkV1TxInfoAssetIdV1, checkV1TxInfoMintWitnessV1, checkV1TxInfoRedeemer, txInfoData,
                                txInfoFee, txInfoInputs, txInfoMint, txInfoOutputs, txInfoSigs)
 
+
+checkTxInfoV1TestInfo = TestInfo {
+    testName="checkTxInfoV1Test",
+    testDescription="Check each attribute of the TxInfo from the V1 ScriptContext in a single transaction"
+    }
 checkTxInfoV1Test :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -111,7 +112,10 @@ checkTxInfoV1Test networkOptions TestParams{..} preTestnetTime = do
 
   H.success
 
--- tests spending outputs with datum hash both with and without datum value embedded in tx body
+datumHashSpendTestInfo = TestInfo {
+    testName="datumHashSpendTest",
+    testDescription="Test spending outputs with datum hash both with and without datum value embedded in tx body"
+    }
 datumHashSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -172,6 +176,10 @@ datumHashSpendTest networkOptions TestParams{..} = do
 
   H.success
 
+mintBurnTestInfo = TestInfo {
+    testName="mintBurnTest",
+    testDescription="Mint some tokens with Plutus policy in one transaction and then burn some of them in second transaction"
+    }
 mintBurnTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -234,6 +242,10 @@ mintBurnTest networkOptions TestParams{..} = do
 
   H.success
 
+collateralContainsTokenErrorTestInfo = TestInfo {
+    testName="collateralContainsTokenErrorTest",
+    testDescription="CollateralContainsNonADA error occurs when including tokens in a collateral input"
+    }
 collateralContainsTokenErrorTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -293,6 +305,10 @@ collateralContainsTokenErrorTest networkOptions TestParams{..} = do
 
   H.success
 
+missingCollateralInputErrorTestInfo = TestInfo {
+    testName="missingCollateralInputErrorTest",
+    testDescription="TxBodyEmptyTxInsCollateral error occurs when collateral input is required but txbody's txInsCollateral is missing"
+    }
 missingCollateralInputErrorTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -321,6 +337,10 @@ missingCollateralInputErrorTest networkOptions TestParams{..} = do
   H.assert $ Tx.isTxBodyError "TxBodyEmptyTxInsCollateral" eitherTx
   H.success
 
+noCollateralInputsErrorTestInfo = TestInfo {
+    testName="noCollateralInputsErrorTest",
+    testDescription="NoCollateralInputs error occurs when collateral is required but txbody's txInsCollateral is empty"
+    }
 noCollateralInputsErrorTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -353,6 +373,10 @@ noCollateralInputsErrorTest networkOptions TestParams{..} = do
   H.assert $ Tx.isSubmitError "NoCollateralInputs" eitherSubmit
   H.success
 
+tooManyCollateralInputsErrorTestInfo = TestInfo {
+    testName="tooManyCollateralInputsErrorTest",
+    testDescription="TooManyCollateralInputs error occurs when number of collateral inputs exceed protocol param 'maxCollateralInputs'"
+    }
 tooManyCollateralInputsErrorTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->

--- a/e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/e2e-tests/test/Spec/BabbageFeatures.hs
@@ -19,12 +19,13 @@ import Hedgehog qualified as H
 
 import CardanoTestnet qualified as TN
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Time.Clock.POSIX (POSIXTime)
+import Data.Maybe (fromJust)
 import Data.Time.Clock.POSIX qualified as Time
 import Hedgehog.Internal.Property (MonadTest)
 import Helpers.Common (makeAddress)
 import Helpers.Query qualified as Q
-import Helpers.Test (TestParams (TestParams, localNodeConnectInfo, networkId, pparams, tempAbsPath), assert, success)
+import Helpers.Test (assert)
+import Helpers.TestData (TestParams (..))
 import Helpers.TestResults (TestInfo (..))
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
@@ -38,15 +39,14 @@ import PlutusScripts.V2TxInfo (checkV2TxInfoAssetIdV2, checkV2TxInfoMintWitnessV
                                txInfoFee, txInfoInputs, txInfoMint, txInfoOutputs, txInfoSigs)
 
 checkTxInfoV2TestInfo = TestInfo {
-    testName="checkTxInfoV2Test",
-    testDescription="Check each attribute of the TxInfo from the V2 ScriptContext in a single transaction"
-    }
+    testName = "checkTxInfoV2Test",
+    testDescription = "Check each attribute of the TxInfo from the V2 ScriptContext in a single transaction",
+    test = checkTxInfoV2Test }
 checkTxInfoV2Test :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  POSIXTime ->
   m (Maybe String)
-checkTxInfoV2Test networkOptions TestParams{..} preTestnetTime = do
+checkTxInfoV2Test networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
   startTime <- liftIO Time.getPOSIXTime
@@ -72,7 +72,7 @@ checkTxInfoV2Test networkOptions TestParams{..} preTestnetTime = do
     txOut2 = Tx.txOut era (C.lovelaceToValue amountReturned) w1Address
 
     lowerBound = PlutusV1.fromMilliSeconds
-      $ PlutusV1.DiffMilliSeconds $ U.posixToMilliseconds preTestnetTime -- before slot 1
+      $ PlutusV1.DiffMilliSeconds $ U.posixToMilliseconds $ fromJust mTime -- before slot 1
     upperBound = PlutusV1.fromMilliSeconds
       $ PlutusV1.DiffMilliSeconds $ U.posixToMilliseconds startTime + 600_000 -- ~10mins after slot 1 (to account for testnet init time)
     timeRange = PlutusV1.interval lowerBound upperBound :: PlutusV1.POSIXTimeRange
@@ -116,9 +116,9 @@ checkTxInfoV2Test networkOptions TestParams{..} preTestnetTime = do
 
 
 referenceScriptMintTestInfo = TestInfo {
-    testName="referenceScriptMintTest",
-    testDescription="Mint tokens by referencing an input containing a Plutus policy as witness"
-    }
+    testName = "referenceScriptMintTest",
+    testDescription = "Mint tokens by referencing an input containing a Plutus policy as witness",
+    test = referenceScriptMintTest }
 referenceScriptMintTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -173,9 +173,9 @@ referenceScriptMintTest networkOptions TestParams{..} = do
   assert "txOut has tokens" txOutHasTokenValue
 
 referenceScriptInlineDatumSpendTestInfo = TestInfo {
-    testName="referenceScriptInlineDatumSpendTest",
-    testDescription="Spend funds locked by script by using inline datum and referencing an input containing a Plutus script as witness"
-    }
+    testName = "referenceScriptInlineDatumSpendTest",
+    testDescription = "Spend funds locked by script by using inline datum and referencing an input containing a Plutus script as witness",
+    test = referenceScriptInlineDatumSpendTest}
 referenceScriptInlineDatumSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -232,9 +232,9 @@ referenceScriptInlineDatumSpendTest networkOptions TestParams{..} = do
   assert "txOut has tokens" txOutHasAdaValue
 
 referenceScriptDatumHashSpendTestInfo = TestInfo {
-    testName="referenceScriptDatumHashSpendTest",
-    testDescription="Spend funds locked by script by providing datum in txbody and referencing an input containing a Plutus script as witness"
-    }
+    testName = "referenceScriptDatumHashSpendTest",
+    testDescription = "Spend funds locked by script by providing datum in txbody and referencing an input containing a Plutus script as witness",
+    test = referenceScriptDatumHashSpendTest}
 referenceScriptDatumHashSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -292,9 +292,9 @@ referenceScriptDatumHashSpendTest networkOptions TestParams{..} = do
   assert "txOut has tokens" txOutHasAdaValue
 
 inlineDatumSpendTestInfo = TestInfo {
-    testName="inlineDatumSpendTest",
-    testDescription="Spend funds locked by script by using inline datum and providing Plutus script in transaction as witness"
-    }
+    testName = "inlineDatumSpendTest",
+    testDescription = "Spend funds locked by script by using inline datum and providing Plutus script in transaction as witness",
+    test = inlineDatumSpendTest}
 inlineDatumSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -347,9 +347,9 @@ inlineDatumSpendTest networkOptions TestParams{..} = do
   assert "txOut has tokens" txOutHasAdaValue
 
 referenceInputWithV1ScriptErrorTestInfo = TestInfo {
-    testName="referenceInputWithV1ScriptErrorTest",
-    testDescription="ReferenceInputsNotSupported error occurs when executing a V1 script whilst referencing an input"
-    }
+    testName = "referenceInputWithV1ScriptErrorTest",
+    testDescription = "ReferenceInputsNotSupported error occurs when executing a V1 script whilst referencing an input",
+    test = referenceInputWithV1ScriptErrorTest}
 referenceInputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -380,9 +380,9 @@ referenceInputWithV1ScriptErrorTest networkOptions TestParams{..} = do
   assert expError $ Tx.isTxBodyErrorValidityInterval expError eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
 
 referenceScriptOutputWithV1ScriptErrorTestInfo = TestInfo {
-    testName="referenceScriptOutputWithV1ScriptErrorTest",
-    testDescription="ReferenceScriptsNotSupported error occurs when executing a V1 script whilst creating an output including a reference script"
-    }
+    testName = "referenceScriptOutputWithV1ScriptErrorTest",
+    testDescription = "ReferenceScriptsNotSupported error occurs when executing a V1 script whilst creating an output including a reference script",
+    test = referenceScriptOutputWithV1ScriptErrorTest}
 referenceScriptOutputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -414,9 +414,9 @@ referenceScriptOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
   assert expError $ Tx.isTxBodyErrorValidityInterval expError eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
 
 inlineDatumOutputWithV1ScriptErrorTestInfo = TestInfo {
-    testName="inlineDatumOutputWithV1ScriptErrorTest",
-    testDescription="InlineDatumsNotSupported error occurs when executing a V1 script whilst creating an output including an inline datum"
-    }
+    testName = "inlineDatumOutputWithV1ScriptErrorTest",
+    testDescription = "InlineDatumsNotSupported error occurs when executing a V1 script whilst creating an output including an inline datum",
+    test = inlineDatumOutputWithV1ScriptErrorTest}
 inlineDatumOutputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -447,9 +447,9 @@ inlineDatumOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
   assert expError $ Tx.isTxBodyErrorValidityInterval expError eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
 
 returnCollateralWithTokensValidScriptTestInfo = TestInfo {
-    testName="returnCollateralWithTokensValidScriptTest",
-    testDescription="Check it is possible to provide collateral input containing tokens if return collateral is being used to return them"
-    }
+    testName = "returnCollateralWithTokensValidScriptTest",
+    testDescription = "Check it is possible to provide collateral input containing tokens if return collateral is being used to return them",
+    test = returnCollateralWithTokensValidScriptTest}
 returnCollateralWithTokensValidScriptTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -507,11 +507,11 @@ returnCollateralWithTokensValidScriptTest networkOptions TestParams{..} = do
   assert "txOut has tokens" txOutHasTokenValue
 
 submitWithInvalidScriptThenCollateralIsTakenAndReturnedTestInfo = TestInfo {
-    testName="submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest",
-    testDescription="Submit a failing script when using total and return collateral in tx body." ++
+    testName = "submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest",
+    testDescription = "Submit a failing script when using total and return collateral in tx body." ++
        "Check that ada and tokens from collateral input are returned in the collateral output." ++
-       "and that the regular input is not consumed."
-    }
+       "and that the regular input is not consumed.",
+    test = submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest}
 submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -583,6 +583,6 @@ submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest networkOptions TestP
   -- Query regular tx input and assert it has not been spent
   txInNotSpent <- Q.isTxOutAtAddress era localNodeConnectInfo w1Address txIn2
   a3 <- assert "txIn not spent" txInNotSpent
-  U.concatMaybesList [a1, a2, a3]
+  U.concatMaybes [a1, a2, a3]
 
 -- TODO: access datum in reference input in plutus script

--- a/e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/e2e-tests/test/Spec/BabbageFeatures.hs
@@ -24,7 +24,7 @@ import Data.Time.Clock.POSIX qualified as Time
 import Hedgehog.Internal.Property (MonadTest)
 import Helpers.Common (makeAddress)
 import Helpers.Query qualified as Q
-import Helpers.Test (TestParams (TestParams, localNodeConnectInfo, networkId, pparams, tempAbsPath))
+import Helpers.Test (TestParams (TestParams, localNodeConnectInfo, networkId, pparams, tempAbsPath), assert, success)
 import Helpers.TestResults (TestInfo (..))
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
@@ -45,7 +45,7 @@ checkTxInfoV2Test :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
   POSIXTime ->
-  m ()
+  m (Maybe String)
 checkTxInfoV2Test networkOptions TestParams{..} preTestnetTime = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -112,9 +112,8 @@ checkTxInfoV2Test networkOptions TestParams{..} preTestnetTime = do
   let expectedTxIn = Tx.txIn (Tx.txId signedTx) 0
   resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "resultTxOut <- getTxOutAtAddress "
   txOutHasTokenValue <- Q.txOutHasValue resultTxOut tokenValues
-  H.assert txOutHasTokenValue
+  assert "txOut has tokens" txOutHasTokenValue
 
-  H.success
 
 referenceScriptMintTestInfo = TestInfo {
     testName="referenceScriptMintTest",
@@ -123,7 +122,7 @@ referenceScriptMintTestInfo = TestInfo {
 referenceScriptMintTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 referenceScriptMintTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -171,9 +170,7 @@ referenceScriptMintTest networkOptions TestParams{..} = do
   -- Query for txo and assert it contains newly minted token
   resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "getTxOutAtAddress"
   txOutHasTokenValue <- Q.txOutHasValue resultTxOut tokenValues
-  H.assert txOutHasTokenValue
-
-  H.success
+  assert "txOut has tokens" txOutHasTokenValue
 
 referenceScriptInlineDatumSpendTestInfo = TestInfo {
     testName="referenceScriptInlineDatumSpendTest",
@@ -182,7 +179,7 @@ referenceScriptInlineDatumSpendTestInfo = TestInfo {
 referenceScriptInlineDatumSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 referenceScriptInlineDatumSpendTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -232,9 +229,7 @@ referenceScriptInlineDatumSpendTest networkOptions TestParams{..} = do
   -- Query for txo and assert it contains newly minted token
   resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "getTxOutAtAddress"
   txOutHasAdaValue <- Q.txOutHasValue resultTxOut adaValue
-  H.assert txOutHasAdaValue
-
-  H.success
+  assert "txOut has tokens" txOutHasAdaValue
 
 referenceScriptDatumHashSpendTestInfo = TestInfo {
     testName="referenceScriptDatumHashSpendTest",
@@ -243,7 +238,7 @@ referenceScriptDatumHashSpendTestInfo = TestInfo {
 referenceScriptDatumHashSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 referenceScriptDatumHashSpendTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -294,9 +289,7 @@ referenceScriptDatumHashSpendTest networkOptions TestParams{..} = do
   -- Query for txo and assert it contains newly minted token
   resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "getTxOutAtAddress"
   txOutHasAdaValue <- Q.txOutHasValue resultTxOut adaValue
-  H.assert txOutHasAdaValue
-
-  H.success
+  assert "txOut has tokens" txOutHasAdaValue
 
 inlineDatumSpendTestInfo = TestInfo {
     testName="inlineDatumSpendTest",
@@ -305,7 +298,7 @@ inlineDatumSpendTestInfo = TestInfo {
 inlineDatumSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 inlineDatumSpendTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -351,9 +344,7 @@ inlineDatumSpendTest networkOptions TestParams{..} = do
   -- Query for txo and assert it contains newly minted token
   resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "getTxOutAtAddress"
   txOutHasAdaValue <- Q.txOutHasValue resultTxOut adaValue
-  H.assert txOutHasAdaValue
-
-  H.success
+  assert "txOut has tokens" txOutHasAdaValue
 
 referenceInputWithV1ScriptErrorTestInfo = TestInfo {
     testName="referenceInputWithV1ScriptErrorTest",
@@ -362,7 +353,7 @@ referenceInputWithV1ScriptErrorTestInfo = TestInfo {
 referenceInputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 referenceInputWithV1ScriptErrorTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -385,8 +376,8 @@ referenceInputWithV1ScriptErrorTest networkOptions TestParams{..} = do
       }
 
   eitherTx <- Tx.buildTx' era txBodyContent w1Address w1SKey networkId
-  H.assert $ Tx.isTxBodyErrorValidityInterval "ReferenceInputsNotSupported" eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
-  H.success
+  let expError = "ReferenceInputsNotSupported"
+  assert expError $ Tx.isTxBodyErrorValidityInterval expError eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
 
 referenceScriptOutputWithV1ScriptErrorTestInfo = TestInfo {
     testName="referenceScriptOutputWithV1ScriptErrorTest",
@@ -395,7 +386,7 @@ referenceScriptOutputWithV1ScriptErrorTestInfo = TestInfo {
 referenceScriptOutputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 referenceScriptOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -419,8 +410,8 @@ referenceScriptOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
 
   eitherTx <- Tx.buildTx' era txBodyContent w1Address w1SKey networkId
   H.annotate $ show eitherTx
-  H.assert $ Tx.isTxBodyErrorValidityInterval "ReferenceScriptsNotSupported" eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
-  H.success
+  let expError = "ReferenceScriptsNotSupported"
+  assert expError $ Tx.isTxBodyErrorValidityInterval expError eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
 
 inlineDatumOutputWithV1ScriptErrorTestInfo = TestInfo {
     testName="inlineDatumOutputWithV1ScriptErrorTest",
@@ -429,7 +420,7 @@ inlineDatumOutputWithV1ScriptErrorTestInfo = TestInfo {
 inlineDatumOutputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 inlineDatumOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -452,8 +443,8 @@ inlineDatumOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
 
   eitherTx <- Tx.buildTx' era txBodyContent w1Address w1SKey networkId
   H.annotate $ show eitherTx
-  H.assert $ Tx.isTxBodyErrorValidityInterval "InlineDatumsNotSupported" eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
-  H.success
+  let expError = "InlineDatumsNotSupported"
+  assert expError $ Tx.isTxBodyErrorValidityInterval expError eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
 
 returnCollateralWithTokensValidScriptTestInfo = TestInfo {
     testName="returnCollateralWithTokensValidScriptTest",
@@ -462,7 +453,7 @@ returnCollateralWithTokensValidScriptTestInfo = TestInfo {
 returnCollateralWithTokensValidScriptTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 returnCollateralWithTokensValidScriptTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -513,9 +504,7 @@ returnCollateralWithTokensValidScriptTest networkOptions TestParams{..} = do
   -- Query for txo and assert it contains newly minted token
   resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "getTxOutAtAddress"
   txOutHasTokenValue <- Q.txOutHasValue resultTxOut tokenValues2
-  H.assert txOutHasTokenValue
-
-  H.success
+  assert "txOut has tokens" txOutHasTokenValue
 
 submitWithInvalidScriptThenCollateralIsTakenAndReturnedTestInfo = TestInfo {
     testName="submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest",
@@ -526,7 +515,7 @@ submitWithInvalidScriptThenCollateralIsTakenAndReturnedTestInfo = TestInfo {
 submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
-  m ()
+  m (Maybe String)
 submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest networkOptions TestParams{..} = do
 
   C.AnyCardanoEra era <- TN.eraFromOptions networkOptions
@@ -587,14 +576,13 @@ submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest networkOptions TestP
   let expectedTxIn = Tx.txIn (Tx.txId signedTx2) 3 -- collateral return index is n outputs (including change)
   resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "getTxOutAtAddress"
   txOutHasAdaAndTokenValue <- Q.txOutHasValue resultTxOut colReturnValue
-  H.assert txOutHasAdaAndTokenValue
+  a1 <- assert "txOut has tokens" txOutHasAdaAndTokenValue
   -- Query collateral input and assert it has been spent
   collateralSpent <- not <$> Q.isTxOutAtAddress era localNodeConnectInfo w1Address collateralTxIn
-  H.assert collateralSpent
+  a2 <- assert "collateral spent" collateralSpent
   -- Query regular tx input and assert it has not been spent
   txInNotSpent <- Q.isTxOutAtAddress era localNodeConnectInfo w1Address txIn2
-  H.assert txInNotSpent
-
-  H.success
+  a3 <- assert "txIn not spent" txInNotSpent
+  U.concatMaybesList [a1, a2, a3]
 
 -- TODO: access datum in reference input in plutus script

--- a/e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/e2e-tests/test/Spec/BabbageFeatures.hs
@@ -6,19 +6,11 @@
 {-# OPTIONS_GHC -fno-warn-incomplete-patterns #-} -- Not using all CardanoEra
 {-# OPTIONS_GHC -Wno-unused-do-bind #-}
 {-# LANGUAGE RecordWildCards     #-}
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-module Spec.BabbageFeatures(
-    checkTxInfoV2Test,
-    referenceScriptMintTest,
-    referenceScriptInlineDatumSpendTest,
-    referenceScriptDatumHashSpendTest,
-    inlineDatumSpendTest,
-    referenceInputWithV1ScriptErrorTest,
-    referenceScriptOutputWithV1ScriptErrorTest,
-    inlineDatumOutputWithV1ScriptErrorTest,
-    returnCollateralWithTokensValidScriptTest,
-    submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest
-    ) where
+module Spec.BabbageFeatures where
 
 import Cardano.Api qualified as C
 import Data.Map qualified as Map
@@ -33,6 +25,7 @@ import Hedgehog.Internal.Property (MonadTest)
 import Helpers.Common (makeAddress)
 import Helpers.Query qualified as Q
 import Helpers.Test (TestParams (TestParams, localNodeConnectInfo, networkId, pparams, tempAbsPath))
+import Helpers.TestResults (TestInfo (..))
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
 import Helpers.Utils qualified as U
@@ -44,7 +37,10 @@ import PlutusScripts.Helpers qualified as PS
 import PlutusScripts.V2TxInfo (checkV2TxInfoAssetIdV2, checkV2TxInfoMintWitnessV2, checkV2TxInfoRedeemer, txInfoData,
                                txInfoFee, txInfoInputs, txInfoMint, txInfoOutputs, txInfoSigs)
 
--- | Test must be first to run after new testnet is initialised due to slot timing
+checkTxInfoV2TestInfo = TestInfo {
+    testName="checkTxInfoV2Test",
+    testDescription="Check each attribute of the TxInfo from the V2 ScriptContext in a single transaction"
+    }
 checkTxInfoV2Test :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -120,6 +116,10 @@ checkTxInfoV2Test networkOptions TestParams{..} preTestnetTime = do
 
   H.success
 
+referenceScriptMintTestInfo = TestInfo {
+    testName="referenceScriptMintTest",
+    testDescription="Mint tokens by referencing an input containing a Plutus policy as witness"
+    }
 referenceScriptMintTest :: (MonadTest m, MonadIO m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -175,6 +175,10 @@ referenceScriptMintTest networkOptions TestParams{..} = do
 
   H.success
 
+referenceScriptInlineDatumSpendTestInfo = TestInfo {
+    testName="referenceScriptInlineDatumSpendTest",
+    testDescription="Spend funds locked by script by using inline datum and referencing an input containing a Plutus script as witness"
+    }
 referenceScriptInlineDatumSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -232,6 +236,10 @@ referenceScriptInlineDatumSpendTest networkOptions TestParams{..} = do
 
   H.success
 
+referenceScriptDatumHashSpendTestInfo = TestInfo {
+    testName="referenceScriptDatumHashSpendTest",
+    testDescription="Spend funds locked by script by providing datum in txbody and referencing an input containing a Plutus script as witness"
+    }
 referenceScriptDatumHashSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -290,6 +298,10 @@ referenceScriptDatumHashSpendTest networkOptions TestParams{..} = do
 
   H.success
 
+inlineDatumSpendTestInfo = TestInfo {
+    testName="inlineDatumSpendTest",
+    testDescription="Spend funds locked by script by using inline datum and providing Plutus script in transaction as witness"
+    }
 inlineDatumSpendTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -343,6 +355,10 @@ inlineDatumSpendTest networkOptions TestParams{..} = do
 
   H.success
 
+referenceInputWithV1ScriptErrorTestInfo = TestInfo {
+    testName="referenceInputWithV1ScriptErrorTest",
+    testDescription="ReferenceInputsNotSupported error occurs when executing a V1 script whilst referencing an input"
+    }
 referenceInputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -372,6 +388,10 @@ referenceInputWithV1ScriptErrorTest networkOptions TestParams{..} = do
   H.assert $ Tx.isTxBodyErrorValidityInterval "ReferenceInputsNotSupported" eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
   H.success
 
+referenceScriptOutputWithV1ScriptErrorTestInfo = TestInfo {
+    testName="referenceScriptOutputWithV1ScriptErrorTest",
+    testDescription="ReferenceScriptsNotSupported error occurs when executing a V1 script whilst creating an output including a reference script"
+    }
 referenceScriptOutputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -402,6 +422,10 @@ referenceScriptOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
   H.assert $ Tx.isTxBodyErrorValidityInterval "ReferenceScriptsNotSupported" eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
   H.success
 
+inlineDatumOutputWithV1ScriptErrorTestInfo = TestInfo {
+    testName="inlineDatumOutputWithV1ScriptErrorTest",
+    testDescription="InlineDatumsNotSupported error occurs when executing a V1 script whilst creating an output including an inline datum"
+    }
 inlineDatumOutputWithV1ScriptErrorTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -431,6 +455,10 @@ inlineDatumOutputWithV1ScriptErrorTest networkOptions TestParams{..} = do
   H.assert $ Tx.isTxBodyErrorValidityInterval "InlineDatumsNotSupported" eitherTx -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
   H.success
 
+returnCollateralWithTokensValidScriptTestInfo = TestInfo {
+    testName="returnCollateralWithTokensValidScriptTest",
+    testDescription="Check it is possible to provide collateral input containing tokens if return collateral is being used to return them"
+    }
 returnCollateralWithTokensValidScriptTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -489,9 +517,12 @@ returnCollateralWithTokensValidScriptTest networkOptions TestParams{..} = do
 
   H.success
 
--- Submit a failing script when using total and return collateral in tx body.
--- Check that ada and tokens from collateral input are returned in the collateral output.
--- Also check that regular input is not consumed.
+submitWithInvalidScriptThenCollateralIsTakenAndReturnedTestInfo = TestInfo {
+    testName="submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest",
+    testDescription="Submit a failing script when using total and return collateral in tx body." ++
+       "Check that ada and tokens from collateral input are returned in the collateral output." ++
+       "and that the regular input is not consumed."
+    }
 submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->

--- a/e2e-tests/test/Spec/Builtins/SECP256k1.hs
+++ b/e2e-tests/test/Spec/Builtins/SECP256k1.hs
@@ -19,7 +19,8 @@ import CardanoTestnet qualified as TN
 import Control.Monad.IO.Class (MonadIO)
 import Hedgehog (MonadTest)
 import Helpers.Query qualified as Q
-import Helpers.Test (TestParams (TestParams, localNodeConnectInfo, networkId, pparams, tempAbsPath), assert)
+import Helpers.Test (assert)
+import Helpers.TestData (TestParams (..))
 import Helpers.TestResults (TestInfo (..))
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
@@ -27,9 +28,9 @@ import Helpers.Utils qualified as U
 import PlutusScripts.SECP256k1 qualified as PS
 
 verifySchnorrAndEcdsaTestInfo = TestInfo {
-    testName="verifySchnorrAndEcdsaTest",
-    testDescription="SECP256k1 builtin verify functions verifySchnorrSecp256k1Signature and verifyEcdsaSecp256k1Signature can only be used to mint in Babbage era protocol version 8 and beyond."
-    }
+    testName = "verifySchnorrAndEcdsaTest",
+    testDescription = "SECP256k1 builtin verify functions verifySchnorrSecp256k1Signature and verifyEcdsaSecp256k1Signature can only be used to mint in Babbage era protocol version 8 and beyond.",
+    test = verifySchnorrAndEcdsaTest}
 verifySchnorrAndEcdsaTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -78,7 +79,7 @@ verifySchnorrAndEcdsaTest networkOptions TestParams{..} = do
         expErrorEcdsa = "Forbidden builtin function: (builtin verifyEcdsaSecp256k1Signature)"
       a1 <- assert expErrorSchnorr $ Tx.isTxBodyScriptExecutionError expErrorSchnorr eitherTx
       a2 <- assert expErrorEcdsa $ Tx.isTxBodyScriptExecutionError expErrorEcdsa eitherTx
-      U.concatMaybesList [a1, a2]
+      U.concatMaybes [a1, a2]
 
     False -> do
       -- Build and submit transaction

--- a/e2e-tests/test/Spec/Builtins/SECP256k1.hs
+++ b/e2e-tests/test/Spec/Builtins/SECP256k1.hs
@@ -7,8 +7,10 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 {-# HLINT ignore "Use if" #-}
 {-# LANGUAGE RecordWildCards     #-}
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
 
-module Spec.Builtins.SECP256k1(verifySchnorrAndEcdsaTest) where
+module Spec.Builtins.SECP256k1 where
 
 import Cardano.Api qualified as C
 import Data.Map qualified as Map
@@ -20,19 +22,15 @@ import Control.Monad.IO.Class (MonadIO)
 import Hedgehog (MonadTest)
 import Helpers.Query qualified as Q
 import Helpers.Test (TestParams (TestParams, localNodeConnectInfo, networkId, pparams, tempAbsPath))
+import Helpers.TestResults (TestInfo (..))
 import Helpers.Testnet qualified as TN
 import Helpers.Tx qualified as Tx
 import PlutusScripts.SECP256k1 qualified as PS
 
-{- | Test that builtins: verifySchnorrSecp256k1Signature and verifyEcdsaSecp256k1Signature can only
-   be used to mint in Babbage era protocol version 8 and beyond.
-
-   Steps:
-    - spin up a testnet
-    - build and submit a transaction to mint a token using the two SECP256k1 builtins
-    - if pv8+ then query the ledger to see if mint was successful otherwise expect
-        "forbidden builtin" error when building tx
--}
+verifySchnorrAndEcdsaTestInfo = TestInfo {
+    testName="verifySchnorrAndEcdsaTest",
+    testDescription="SECP256k1 builtin verify functions verifySchnorrSecp256k1Signature and verifyEcdsaSecp256k1Signature can only be used to mint in Babbage era protocol version 8 and beyond."
+    }
 verifySchnorrAndEcdsaTest :: (MonadIO m , MonadTest m) =>
   Either TN.LocalNodeOptions TN.TestnetOptions ->
   TestParams ->
@@ -92,5 +90,5 @@ verifySchnorrAndEcdsaTest networkOptions TestParams{..} = do
       resultTxOut <- Q.getTxOutAtAddress era localNodeConnectInfo w1Address expectedTxIn "TN.getTxOutAtAddress"
       txOutHasTokenValue <- Q.txOutHasValue resultTxOut tokenValues
       H.assert txOutHasTokenValue
-
       H.success
+


### PR DESCRIPTION
Can run `allure serve antaeus/e2e-tests/test-report-xml` to generate and host Allure report that looks like:

![Screenshot_20230427_172226](https://user-images.githubusercontent.com/74595920/234929544-3a48c011-c7f6-4324-97d2-331f26763a9c.png)

![Screenshot_20230427_172207](https://user-images.githubusercontent.com/74595920/234929526-6ea2c56f-c787-45f6-9b29-99d307659f0e.png)