### PR TITLE
Revert "Add cardano-node-emulator support (#77)"

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING.adoc for how to update index-state
 index-state:
   , hackage.haskell.org 2023-12-08T11:11:00Z
-  , cardano-haskell-packages 2023-12-22T13:20:40Z
+  , cardano-haskell-packages 2023-12-08T11:11:00Z
 packages: e2e-tests
 
 -- We never, ever, want this.
@@ -53,20 +53,6 @@ constraints:
 source-repository-package
     type: git
     location: https://github.com/james-iohk/cardano-node
-    --sha256: sha256-kej3cZaQDFoo7EbCqowGTV/T7sn3tC+C9pL+sfY5d+8=
     tag: bc17a94280d73b605e6ffd6c7895996d93e7293a
     subdir:
       cardano-testnet
-
--- TODO: remove once this version is on CHaP
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-node-emulator
-    tag: 1e09173b74064bd5990d2d3e48af6510780ea349
-    --sha256: sha256-Woa4iK4CegMV99EV3YXnmwZ/2Ov6wgtleGzSxNpce5g=
-    subdir:
-      plutus-ledger
-      plutus-script-utils
-      cardano-node-emulator
-      cardano-node-socket-emulator
-      freer-extras

--- a/e2e-tests/e2e-tests.cabal
+++ b/e2e-tests/e2e-tests.cabal
@@ -63,8 +63,6 @@ common lang
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-ledger-shelley
-    , cardano-node-emulator
-    , cardano-node-socket-emulator
     , cardano-protocol-tpraos
     , cardano-slotting
     , cardano-strict-containers
@@ -197,7 +195,6 @@ test-suite antaeus-test
     , bytestring
     , cborg
     , containers
-    , data-default
     , deepseq
     , directory
     , exceptions

--- a/e2e-tests/test/Helpers/Committee.hs
+++ b/e2e-tests/test/Helpers/Committee.hs
@@ -56,6 +56,5 @@ generateCommitteeKeysAndCertificate ceo = do
       committeeHotKeyAuthCert
       committeeVoter
 
-castCommittee :: C.SigningKey C.CommitteeHotKey -> C.ShelleyWitnessSigningKey
-castCommittee (C.CommitteeHotSigningKey committeeHotSK) =
-  C.WitnessPaymentKey $ C.PaymentSigningKey committeeHotSK
+castCommittee :: C.SigningKey C.CommitteeHotKey -> C.SigningKey C.PaymentKey
+castCommittee (C.CommitteeHotSigningKey committeeHotSK) = C.PaymentSigningKey committeeHotSK

--- a/e2e-tests/test/Helpers/Common.hs
+++ b/e2e-tests/test/Helpers/Common.hs
@@ -49,24 +49,24 @@ withIsShelleyBasedEra era r =
     _ -> error "Must use Alonzo, Babbage or Conway era"
 
 makeAddress
-  :: Either (C.Hash C.PaymentKey) C.ScriptHash
+  :: Either (C.VerificationKey C.PaymentKey) C.ScriptHash
   -> C.NetworkId
   -> C.Address C.ShelleyAddr
 makeAddress ePkSh = makeAddressWithStake ePkSh Nothing
 
 -- | Make a payment or script address
 makeAddressWithStake
-  :: Either (C.Hash C.PaymentKey) C.ScriptHash
-  -> Maybe (C.Hash C.StakeKey)
+  :: Either (C.VerificationKey C.PaymentKey) C.ScriptHash
+  -> Maybe (C.VerificationKey C.StakeKey)
   -> C.NetworkId
   -> C.Address C.ShelleyAddr
-makeAddressWithStake (Left paymentKeyHash) mStakeVKeyHash nId =
+makeAddressWithStake (Left paymentKey) mStakeVKey nId =
   C.makeShelleyAddress
     nId
-    (C.PaymentCredentialByKey paymentKeyHash)
-    ( case mStakeVKeyHash of
+    (C.PaymentCredentialByKey $ C.verificationKeyHash paymentKey)
+    ( case mStakeVKey of
         Nothing -> C.NoStakeAddress
-        Just stakeVKeyHash -> C.StakeAddressByValue $ C.StakeCredentialByKey stakeVKeyHash
+        Just stakeVKey -> C.StakeAddressByValue $ C.StakeCredentialByKey $ C.verificationKeyHash stakeVKey
     )
-makeAddressWithStake (Right scriptHash) _mStakeVKeyHash nId =
+makeAddressWithStake (Right scriptHash) _mStakeVKey nId =
   C.makeShelleyAddress nId (C.PaymentCredentialByScript scriptHash) C.NoStakeAddress

--- a/e2e-tests/test/Helpers/DRep.hs
+++ b/e2e-tests/test/Helpers/DRep.hs
@@ -88,8 +88,8 @@ alwaysNoConfidenceDRep
   -> m (C.DRep (C.EraCrypto (C.ShelleyLedgerEra era)))
 alwaysNoConfidenceDRep ceo = pure $ C.conwayEraOnwardsConstraints ceo C.DRepAlwaysNoConfidence
 
-castDRep :: C.SigningKey C.DRepKey -> C.ShelleyWitnessSigningKey
-castDRep (C.DRepSigningKey sk) = C.WitnessPaymentKey $ C.PaymentSigningKey sk
+castDRep :: C.SigningKey C.DRepKey -> C.SigningKey C.PaymentKey
+castDRep (C.DRepSigningKey sk) = C.PaymentSigningKey sk
 
 voteDelegateCert
   :: C.ConwayEraOnwards era

--- a/e2e-tests/test/PlutusScripts/V1TxInfo.hs
+++ b/e2e-tests/test/PlutusScripts/V1TxInfo.hs
@@ -96,8 +96,8 @@ txInfoFee = fromCardanoValue . C.lovelaceToValue
 txInfoMint :: C.Value -> PlutusV1.Value
 txInfoMint = fromCardanoValue
 
-txInfoSigs :: [C.Hash C.PaymentKey] -> [PlutusV1.PubKeyHash]
-txInfoSigs = map fromCardanoPaymentKeyHash
+txInfoSigs :: [C.VerificationKey C.PaymentKey] -> [PlutusV1.PubKeyHash]
+txInfoSigs = map (fromCardanoPaymentKeyHash . C.verificationKeyHash)
 
 txInfoData :: [C.HashableScriptData] -> [(PlutusV1.DatumHash, PlutusV1.Datum)]
 txInfoData =

--- a/e2e-tests/test/PlutusScripts/V2TxInfo.hs
+++ b/e2e-tests/test/PlutusScripts/V2TxInfo.hs
@@ -105,8 +105,8 @@ txInfoFee = fromCardanoValue . C.lovelaceToValue
 txInfoMint :: C.Value -> PlutusV2.Value
 txInfoMint = fromCardanoValue
 
-txInfoSigs :: [C.Hash C.PaymentKey] -> [PlutusV2.PubKeyHash]
-txInfoSigs = map fromCardanoPaymentKeyHash
+txInfoSigs :: [C.VerificationKey C.PaymentKey] -> [PlutusV2.PubKeyHash]
+txInfoSigs = map (fromCardanoPaymentKeyHash . C.verificationKeyHash)
 
 txInfoData :: [C.HashableScriptData] -> PlutusV2.Map PlutusV2.DatumHash PlutusV2.Datum
 txInfoData =

--- a/e2e-tests/test/Spec/AlonzoFeatures.hs
+++ b/e2e-tests/test/Spec/AlonzoFeatures.hs
@@ -58,7 +58,7 @@ checkTxInfoV1Test
 checkTxInfoV1Test networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath, mTime} = do
   era <- TN.eraFromOptionsM networkOptions
   startTime <- liftIO Time.getPOSIXTime
-  (w1SKey, _w1VKey, w1VKeyHash, w1Address) <- TN.w1All networkOptions tempAbsPath networkId
+  (w1SKey, w1VKey, w1Address) <- TN.w1All tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction
@@ -98,7 +98,7 @@ checkTxInfoV1Test networkOptions TestParams{localNodeConnectInfo, pparams, netwo
       expTxInfoMint = PS.txInfoMint tokenValues
       expDCert = [] -- not testing any staking registration certificate
       expWdrl = [] -- not testing any staking reward withdrawal
-      expTxInfoSigs = PS.txInfoSigs [w1VKeyHash]
+      expTxInfoSigs = PS.txInfoSigs [w1VKey]
       expTxInfoData = PS.txInfoData [datum]
       expTxInfoValidRange = timeRange
 
@@ -126,10 +126,10 @@ checkTxInfoV1Test networkOptions TestParams{localNodeConnectInfo, pparams, netwo
           , C.txValidityUpperBound = Tx.txValidityUpperBound era 2700
           , -- \^ ~9min range (200ms slots)
             -- \^ Babbage era onwards cannot have upper slot beyond epoch boundary (10_000 slot epoch)
-            C.txExtraKeyWits = Tx.txExtraKeyWits era [w1VKeyHash]
+            C.txExtraKeyWits = Tx.txExtraKeyWits era [w1VKey]
           }
   txbody <- Tx.buildRawTx sbe txBodyContent
-  kw <- Tx.signTx sbe txbody w1SKey
+  kw <- Tx.signTx sbe txbody (C.WitnessPaymentKey w1SKey)
   let signedTx = C.makeSignedTransaction [kw] txbody
 
   Tx.submitTx sbe localNodeConnectInfo signedTx
@@ -160,7 +160,7 @@ datumHashSpendTest
   -> m (Maybe String)
 datumHashSpendTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction with two script outputs to be spent
@@ -246,7 +246,7 @@ mintBurnTest
   -> m (Maybe String)
 mintBurnTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to mint tokens
@@ -353,7 +353,7 @@ collateralContainsTokenErrorTest
   -> m (Maybe String)
 collateralContainsTokenErrorTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to mint tokens
@@ -441,7 +441,7 @@ missingCollateralInputErrorTest
   -> m (Maybe String)
 missingCollateralInputErrorTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to mint tokens
@@ -481,7 +481,7 @@ missingCollateralInputErrorTest networkOptions TestParams{localNodeConnectInfo, 
       txBodyContent
       w1Address
       Nothing
-      [w1SKey]
+      [C.WitnessPaymentKey w1SKey]
   let expError = "TxBodyEmptyTxInsCollateral"
   assert expError $ Tx.isTxBodyError expError eitherTx
 
@@ -501,7 +501,7 @@ noCollateralInputsErrorTest
   -> m (Maybe String)
 noCollateralInputsErrorTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to mint tokens
@@ -558,7 +558,7 @@ tooManyCollateralInputsErrorTest
   -> m (Maybe String)
 tooManyCollateralInputsErrorTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to mint tokens

--- a/e2e-tests/test/Spec/BabbageFeatures.hs
+++ b/e2e-tests/test/Spec/BabbageFeatures.hs
@@ -60,7 +60,7 @@ checkTxInfoV2Test
 checkTxInfoV2Test networkOptions TestParams{..} = do
   era <- TN.eraFromOptionsM networkOptions
   startTime <- liftIO Time.getPOSIXTime
-  (w1SKey, _w1VKey, w1VKeyHash, w1Address) <- TN.w1All networkOptions tempAbsPath networkId
+  (w1SKey, w1VKey, w1Address) <- TN.w1All tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction
@@ -100,7 +100,7 @@ checkTxInfoV2Test networkOptions TestParams{..} = do
       expTxInfoMint = PS.txInfoMint tokenValues
       expDCert = [] -- not testing any staking registration certificate
       expWdrl = PlutusV2.fromList [] -- not testing any staking reward withdrawal
-      expTxInfoSigs = PS.txInfoSigs [w1VKeyHash]
+      expTxInfoSigs = PS.txInfoSigs [w1VKey]
       expTxInfoRedeemers = PS_1_0.alwaysSucceedPolicyTxInfoRedeemerV2
       expTxInfoData = PS.txInfoData [datum]
       expTxInfoValidRange = timeRange
@@ -136,10 +136,10 @@ checkTxInfoV2Test networkOptions TestParams{..} = do
           , C.txValidityUpperBound = Tx.txValidityUpperBound era 2700
           , -- \^ ~9min range (200ms slots)
             -- \^ Babbage era onwards cannot have upper slot beyond epoch boundary (10_000 slot epoch)
-            C.txExtraKeyWits = Tx.txExtraKeyWits era [w1VKeyHash]
+            C.txExtraKeyWits = Tx.txExtraKeyWits era [w1VKey]
           }
   txbody <- Tx.buildRawTx sbe txBodyContent
-  kw <- Tx.signTx sbe txbody w1SKey
+  kw <- Tx.signTx sbe txbody (C.WitnessPaymentKey w1SKey)
   let signedTx = C.makeSignedTransaction [kw] txbody
 
   Tx.submitTx sbe localNodeConnectInfo signedTx
@@ -169,7 +169,7 @@ referenceScriptMintTest
   -> m (Maybe String)
 referenceScriptMintTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to hold reference script
@@ -257,7 +257,7 @@ referenceScriptInlineDatumSpendTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     -- build a transaction to hold reference script
@@ -343,7 +343,7 @@ referenceScriptDatumHashSpendTest
   -> m (Maybe String)
 referenceScriptDatumHashSpendTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to hold reference script
@@ -436,7 +436,7 @@ inlineDatumSpendTest
   -> m (Maybe String)
 inlineDatumSpendTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction to hold inline datum at script address
@@ -507,7 +507,7 @@ referenceInputWithV1ScriptErrorTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     txIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -533,7 +533,7 @@ referenceInputWithV1ScriptErrorTest
         txBodyContent
         w1Address
         Nothing
-        [w1SKey]
+        [C.WitnessPaymentKey w1SKey]
     let expError = "ReferenceInputsNotSupported"
     -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
     assert expError $ Tx.isTxBodyErrorValidityInterval expError eitherTx
@@ -556,7 +556,7 @@ referenceScriptOutputWithV1ScriptErrorTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     txIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -586,7 +586,7 @@ referenceScriptOutputWithV1ScriptErrorTest
         txBodyContent
         w1Address
         Nothing
-        [w1SKey]
+        [C.WitnessPaymentKey w1SKey]
     H.annotate $ show eitherTx
     let expError = "ReferenceScriptsNotSupported"
     -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
@@ -610,7 +610,7 @@ inlineDatumOutputWithV1ScriptErrorTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     txIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -640,7 +640,7 @@ inlineDatumOutputWithV1ScriptErrorTest
         txBodyContent
         w1Address
         Nothing
-        [w1SKey]
+        [C.WitnessPaymentKey w1SKey]
     H.annotate $ show eitherTx
     let expError = "InlineDatumsNotSupported"
     -- why is this validity interval error? https://github.com/input-output-hk/cardano-node/issues/5080
@@ -664,7 +664,7 @@ returnCollateralWithTokensValidScriptTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     txIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -758,7 +758,7 @@ submitWithInvalidScriptThenCollateralIsTakenAndReturnedTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     txIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address

--- a/e2e-tests/test/Spec/Builtins/BLS.hs
+++ b/e2e-tests/test/Spec/Builtins/BLS.hs
@@ -39,7 +39,7 @@ buildAndSubmit
   -> C.TxIn
   -> C.TxInsCollateral era
   -> C.Address C.ShelleyAddr
-  -> C.ShelleyWitnessSigningKey
+  -> C.SigningKey C.PaymentKey
   -> C.AssetId
   -> (C.PolicyId, C.ScriptWitness C.WitCtxMint era)
   -> m (C.Value, C.TxIn)
@@ -79,7 +79,7 @@ verifyBlsFunctionsTest
   -> m (Maybe String)
 verifyBlsFunctionsTest networkOptions TestParams{..} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let numberOfBlsScripts = 9
       sbe = toShelleyBasedEra era
 

--- a/e2e-tests/test/Spec/Builtins/Hashing.hs
+++ b/e2e-tests/test/Spec/Builtins/Hashing.hs
@@ -40,7 +40,7 @@ checkHashingFunctionsTest
   -> m (Maybe String)
 checkHashingFunctionsTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction

--- a/e2e-tests/test/Spec/Builtins/SECP256k1.hs
+++ b/e2e-tests/test/Spec/Builtins/SECP256k1.hs
@@ -13,8 +13,7 @@
 module Spec.Builtins.SECP256k1 where
 
 import Cardano.Api qualified as C
-import Control.Concurrent (threadDelay)
-import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.IO.Class (MonadIO)
 import Data.Map qualified as Map
 import Hedgehog (MonadTest)
 import Hedgehog.Internal.Property (annotate)
@@ -46,12 +45,12 @@ verifySchnorrAndEcdsaTest
 verifySchnorrAndEcdsaTest networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
   pv <- TN.pvFromOptions networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction
+
   txIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
-  liftIO $ threadDelay 1000
 
   let (tokenValues, mintWitnesses, plutusVersion) = case era of
         C.AlonzoEra ->
@@ -99,7 +98,7 @@ verifySchnorrAndEcdsaTest networkOptions TestParams{localNodeConnectInfo, pparam
           txBodyContent
           w1Address
           Nothing
-          [w1SKey]
+          [C.WitnessPaymentKey w1SKey]
       annotate $ show eitherTx
       let expErrorSchnorr =
             "Builtin function VerifySchnorrSecp256k1Signature is not available in language "

--- a/e2e-tests/test/Spec/ConwayFeatures.hs
+++ b/e2e-tests/test/Spec/ConwayFeatures.hs
@@ -80,7 +80,7 @@ checkTxInfoV3Test
 checkTxInfoV3Test networkOptions TestParams{..} = do
   era <- TN.eraFromOptionsM networkOptions
   startTime <- liftIO Time.getPOSIXTime
-  (w1SKey, _w1VKey, w1VKeyHash, w1Address) <- TN.w1All networkOptions tempAbsPath networkId
+  (w1SKey, w1VKey, w1Address) <- TN.w1All tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   -- build a transaction
@@ -121,7 +121,7 @@ checkTxInfoV3Test networkOptions TestParams{..} = do
       expTxInfoMint = PS.txInfoMint tokenValues
       expDCert = [] -- not testing any staking registration certificate
       expWdrl = PlutusV2.fromList [] -- not testing any staking reward withdrawal
-      expTxInfoSigs = PS.txInfoSigs [w1VKeyHash]
+      expTxInfoSigs = PS.txInfoSigs [w1VKey]
       expTxInfoRedeemers = PS_1_0.alwaysSucceedPolicyTxInfoRedeemerV2
       expTxInfoData = PS.txInfoData [datum]
       expTxInfoValidRange = timeRange
@@ -157,10 +157,10 @@ checkTxInfoV3Test networkOptions TestParams{..} = do
           , C.txValidityUpperBound = Tx.txValidityUpperBound era 2700
           , -- \^ ~9min range (200ms slots)
             -- \^ Babbage era onwards cannot have upper slot beyond epoch boundary (10_000 slot epoch)
-            C.txExtraKeyWits = Tx.txExtraKeyWits era [w1VKeyHash]
+            C.txExtraKeyWits = Tx.txExtraKeyWits era [w1VKey]
           }
   txbody <- Tx.buildRawTx sbe txBodyContent
-  kw <- Tx.signTx sbe txbody w1SKey
+  kw <- Tx.signTx sbe txbody (C.WitnessPaymentKey w1SKey)
   let signedTx = C.makeSignedTransaction [kw] txbody
 
   Tx.submitTx sbe localNodeConnectInfo signedTx
@@ -193,7 +193,7 @@ registerStakePoolTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     sPRegTxIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -212,7 +212,7 @@ registerStakePoolTest
         regSPTxBodyContent
         w1Address
         (Just 3)
-        [w1SKey, C.WitnessStakePoolKey sPSKey, C.WitnessStakeKey sPRewardKey]
+        [C.WitnessPaymentKey w1SKey, C.WitnessStakePoolKey sPSKey, C.WitnessStakeKey sPRewardKey]
     Tx.submitTx sbe localNodeConnectInfo signedRegSPTx
     let expTxIn = Tx.txIn (Tx.txId signedRegSPTx) 0
     regDRepResultTxOut <-
@@ -237,7 +237,7 @@ registerStakingTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     w1StakeRegTxIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -257,7 +257,7 @@ registerStakingTest
         w1StakeRegTxBodyContent
         w1Address
         (Just 2) -- witnesses
-        [w1SKey, C.WitnessStakeKey stakeSKey]
+        [C.WitnessPaymentKey w1SKey, C.WitnessStakeKey stakeSKey]
     Tx.submitTx sbe localNodeConnectInfo signedW1StakeRegTx1
     let expTxIn = Tx.txIn (Tx.txId signedW1StakeRegTx1) 1 -- change output
     w1StakeRegResultTxOut <-
@@ -288,7 +288,7 @@ registerDRep
   -> m (Maybe String)
 registerDRep dRepRegCert networkOptions TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
   era <- TN.eraFromOptionsM networkOptions
-  (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+  (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
   let sbe = toShelleyBasedEra era
 
   dRepRegTxIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -327,7 +327,7 @@ registerCommitteeTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     -- register committee
@@ -347,7 +347,7 @@ registerCommitteeTest
         committeeRegTxBodyContent
         w1Address
         (Just 2)
-        [w1SKey, C.WitnessCommitteeColdKey committeeColdSKey]
+        [C.WitnessPaymentKey w1SKey, C.WitnessCommitteeColdKey committeeColdSKey]
     Tx.submitTx sbe localNodeConnectInfo signedCommitteeRegTx
     let expTxIn = Tx.txIn (Tx.txId signedCommitteeRegTx) 0
     regDRepResultTxOut <-
@@ -376,7 +376,7 @@ delegateToDRep
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     stakeDelgTxIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -397,7 +397,7 @@ delegateToDRep
         stakeDelegTxBodyContent
         w1Address
         (Just 2)
-        [w1SKey, C.WitnessStakeKey stakeSKey]
+        [C.WitnessPaymentKey w1SKey, C.WitnessStakeKey stakeSKey]
     Tx.submitTx sbe localNodeConnectInfo signedStakeDelegTx
     let expTxIn = Tx.txIn (Tx.txId signedStakeDelegTx) 0
     stakeDelegResultTxOut <-
@@ -422,7 +422,7 @@ delegateToStakePoolTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let ceo = toConwayEraOnwards era
         sbe = toShelleyBasedEra era
 
@@ -444,7 +444,7 @@ delegateToStakePoolTest
         stakeDelegTxBodyContent
         w1Address
         (Just 2)
-        [w1SKey, C.WitnessStakeKey stakeSKey]
+        [C.WitnessPaymentKey w1SKey, C.WitnessStakeKey stakeSKey]
     Tx.submitTx sbe localNodeConnectInfo signedStakeDelegTx
     let expTxIn = Tx.txIn (Tx.txId signedStakeDelegTx) 0
     stakeDelegResultTxOut <-
@@ -475,7 +475,7 @@ constitutionProposalAndVoteTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
         ceo = toConwayEraOnwards era
 
@@ -569,7 +569,10 @@ constitutionProposalAndVoteTest
         tx2BodyContent
         w1Address
         (Just 3) -- witnesses
-        [w1SKey, DRep.castDRep kDRepSKey, CC.castCommittee committeeHotSKey]
+        [ C.WitnessPaymentKey w1SKey
+        , C.WitnessPaymentKey (DRep.castDRep kDRepSKey)
+        , C.WitnessPaymentKey (CC.castCommittee committeeHotSKey)
+        ]
     Tx.submitTx sbe localNodeConnectInfo signedTx2
     let result2TxIn = Tx.txIn (Tx.txId signedTx2) 0
     result2TxOut <-
@@ -618,7 +621,7 @@ committeeProposalAndVoteTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
         ceo = toConwayEraOnwards era
 
@@ -687,7 +690,10 @@ committeeProposalAndVoteTest
         tx2BodyContent
         w1Address
         (Just 3) -- witnesses
-        [w1SKey, C.WitnessStakePoolKey (sPSKey stakeDelegationPool), DRep.castDRep kDRepSKey]
+        [ C.WitnessPaymentKey w1SKey
+        , C.WitnessStakePoolKey (sPSKey stakeDelegationPool)
+        , C.WitnessPaymentKey (DRep.castDRep kDRepSKey)
+        ]
     Tx.submitTx sbe localNodeConnectInfo signedTx2
     let result2TxIn = Tx.txIn (Tx.txId signedTx2) 0
     result2TxOut <-
@@ -715,7 +721,7 @@ noConfidenceProposalAndVoteTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
         ceo = toConwayEraOnwards era
 
@@ -781,7 +787,10 @@ noConfidenceProposalAndVoteTest
         tx2BodyContent
         w1Address
         (Just 3) -- witnesses
-        [w1SKey, C.WitnessStakePoolKey (sPSKey stakeDelegationPool), DRep.castDRep kDRepSKey]
+        [ C.WitnessPaymentKey w1SKey
+        , C.WitnessStakePoolKey (sPSKey stakeDelegationPool)
+        , C.WitnessPaymentKey (DRep.castDRep kDRepSKey)
+        ]
     Tx.submitTx sbe localNodeConnectInfo signedTx2
     let result2TxIn = Tx.txIn (Tx.txId signedTx2) 0
     result2TxOut <-
@@ -812,7 +821,7 @@ parameterChangeProposalAndVoteTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
         ceo = toConwayEraOnwards era
 
@@ -879,7 +888,10 @@ parameterChangeProposalAndVoteTest
         tx2BodyContent
         w1Address
         (Just 3) -- witnesses
-        [w1SKey, (DRep.castDRep kDRepSKey), (CC.castCommittee committeeHotSKey)]
+        [ C.WitnessPaymentKey w1SKey
+        , C.WitnessPaymentKey (DRep.castDRep kDRepSKey)
+        , C.WitnessPaymentKey (CC.castCommittee committeeHotSKey)
+        ]
     Tx.submitTx sbe localNodeConnectInfo signedTx2
     let result2TxIn = Tx.txIn (Tx.txId signedTx2) 0
     result2TxOut <-
@@ -910,7 +922,7 @@ treasuryWithdrawalProposalAndVoteTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
         ceo = toConwayEraOnwards era
 
@@ -976,7 +988,10 @@ treasuryWithdrawalProposalAndVoteTest
         tx2BodyContent
         w1Address
         (Just 3) -- witnesses
-        [w1SKey, (DRep.castDRep kDRepSKey), (CC.castCommittee committeeHotSKey)]
+        [ C.WitnessPaymentKey w1SKey
+        , C.WitnessPaymentKey (DRep.castDRep kDRepSKey)
+        , C.WitnessPaymentKey (CC.castCommittee committeeHotSKey)
+        ]
     Tx.submitTx sbe localNodeConnectInfo signedTx2
     let result2TxIn = Tx.txIn (Tx.txId signedTx2) 0
     result2TxOut <-
@@ -1014,7 +1029,7 @@ hardForkProposalAndVoteTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
         ceo = toConwayEraOnwards era
 
@@ -1081,10 +1096,10 @@ hardForkProposalAndVoteTest
         tx2BodyContent
         w1Address
         (Just 4) -- witnesses
-        [ w1SKey
+        [ C.WitnessPaymentKey w1SKey
         , C.WitnessStakePoolKey (sPSKey stakeDelegationPool)
-        , DRep.castDRep kDRepSKey
-        , CC.castCommittee committeeHotSKey
+        , C.WitnessPaymentKey (DRep.castDRep kDRepSKey)
+        , C.WitnessPaymentKey (CC.castCommittee committeeHotSKey)
         ]
     Tx.submitTx sbe localNodeConnectInfo signedTx2
     let result2TxIn = Tx.txIn (Tx.txId signedTx2) 0
@@ -1115,7 +1130,7 @@ infoProposalAndVoteTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
         ceo = toConwayEraOnwards era
 
@@ -1180,10 +1195,10 @@ infoProposalAndVoteTest
         tx2BodyContent
         w1Address
         (Just 4) -- witnesses
-        [ w1SKey
+        [ C.WitnessPaymentKey w1SKey
         , C.WitnessStakePoolKey (sPSKey stakeDelegationPool)
-        , DRep.castDRep kDRepSKey
-        , CC.castCommittee committeeHotSKey
+        , C.WitnessPaymentKey (DRep.castDRep kDRepSKey)
+        , C.WitnessPaymentKey (CC.castCommittee committeeHotSKey)
         ]
     Tx.submitTx sbe localNodeConnectInfo signedTx2
     let result2TxIn = Tx.txIn (Tx.txId signedTx2) 0
@@ -1212,7 +1227,7 @@ unregisterDRep
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     unRegDRepTxIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -1227,8 +1242,8 @@ unregisterDRep
           }
       unRegDRepTxWitnesses =
         case dRep of
-          KeyDRep{} -> [w1SKey, DRep.castDRep (kDRepSKey dRep)]
-          ScriptDRep{} -> [w1SKey]
+          KeyDRep{} -> [C.WitnessPaymentKey w1SKey, C.WitnessPaymentKey $ DRep.castDRep (kDRepSKey dRep)]
+          ScriptDRep{} -> [C.WitnessPaymentKey w1SKey]
 
     signedDRepUnregTx <-
       Tx.buildTxWithWitnessOverride
@@ -1262,7 +1277,7 @@ unregisterStakingTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let sbe = toShelleyBasedEra era
 
     stakeDelgTxIn <- Q.adaOnlyTxInAtAddress era localNodeConnectInfo w1Address
@@ -1282,7 +1297,7 @@ unregisterStakingTest
         stakeDelegTxBodyContent
         w1Address
         (Just 2)
-        [w1SKey, C.WitnessStakeKey stakeSKey]
+        [C.WitnessPaymentKey w1SKey, C.WitnessStakeKey stakeSKey]
     Tx.submitTx sbe localNodeConnectInfo signedStakeUnregTx
     let expTxIn = Tx.txIn (Tx.txId signedStakeUnregTx) 0
     stakeDelegResultTxOut <-
@@ -1307,7 +1322,7 @@ retireStakePoolTest
   networkOptions
   TestParams{localNodeConnectInfo, pparams, networkId, tempAbsPath} = do
     era <- TN.eraFromOptionsM networkOptions
-    (w1SKey, w1Address) <- TN.w1 networkOptions tempAbsPath networkId
+    (w1SKey, w1Address) <- TN.w1 tempAbsPath networkId
     let ceo = toConwayEraOnwards era
         sbe = toShelleyBasedEra era
 
@@ -1332,7 +1347,7 @@ retireStakePoolTest
         stakeDelegTxBodyContent
         w1Address
         (Just 2)
-        [w1SKey, C.WitnessStakePoolKey sPSKey]
+        [C.WitnessPaymentKey w1SKey, C.WitnessStakePoolKey sPSKey]
     Tx.submitTx sbe localNodeConnectInfo signedPoolRetireTx
     let expTxIn = Tx.txIn (Tx.txId signedPoolRetireTx) 0
     stakeDelegResultTxOut <-

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1704207160,
-        "narHash": "sha256-vvm56KzA6jEkG3mvwh1LEdK4H4FKxeoOJNz90H8l8dQ=",
+        "lastModified": 1702652949,
+        "narHash": "sha256-mXzabkV/kRjZ2ktfhriP3liwgHVNanQqGNbcqOS0eRU=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "3df392af2a61d61bdac1afd9c3674f27d6aa8efc",
+        "rev": "a3d949478fa632e753c7a075bc65e810ea417e20",
         "type": "github"
       },
       "original": {

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -15,6 +15,10 @@ let
 
       shell.withHoogle = false;
 
+      sha256map = {
+        "https://github.com/james-iohk/cardano-node"."${cardano-node-gitrev}" = "sha256-kej3cZaQDFoo7EbCqowGTV/T7sn3tC+C9pL+sfY5d+8=";
+      };
+
       inputMap = {
         "https://input-output-hk.github.io/cardano-haskell-packages" = inputs.CHaP;
       };


### PR DESCRIPTION
because the emulator cannot keep up with the real node's ledger. emulator functionality must live in a separate branch.

This reverts commit 009e5e979a33ecfd8d18ced317e7fb43284792f8.